### PR TITLE
refactor OmniOperatorFactory and show transOperators in web ui

### DIFF
--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/AbstractOmniOperatorFactory.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/AbstractOmniOperatorFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2020-2022. Huawei Technologies Co., Ltd. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nova.hetu.olk.operator;
+
+import io.prestosql.operator.DriverContext;
+import io.prestosql.operator.Operator;
+import io.prestosql.operator.OperatorFactory;
+import io.prestosql.spi.plan.PlanNodeId;
+import io.prestosql.spi.type.Type;
+
+import java.util.List;
+
+public abstract class AbstractOmniOperatorFactory
+        implements OperatorFactory
+{
+    protected int operatorId;
+
+    protected List<Type> sourceTypes;
+
+    protected PlanNodeId planNodeId;
+
+    @Override
+    public abstract Operator createOperator(DriverContext driverContext);
+
+    @Override
+    public abstract void noMoreOperators();
+
+    @Override
+    public abstract OperatorFactory duplicate();
+
+    @Override
+    public boolean isExtensionOperatorFactory()
+    {
+        return true;
+    }
+
+    @Override
+    public List<Type> getSourceTypes()
+    {
+        return sourceTypes;
+    }
+
+    public int getOperatorId()
+    {
+        return operatorId;
+    }
+
+    public PlanNodeId getPlanNodeId()
+    {
+        return planNodeId;
+    }
+}

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/AggregationOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/AggregationOmniOperator.java
@@ -145,13 +145,9 @@ public class AggregationOmniOperator
      * @since 20210630
      */
     public static class AggregationOmniOperatorFactory
-            implements OperatorFactory
+            extends AbstractOmniOperatorFactory
     {
         private static final int INVALID_MASK_CHANNEL = -1;
-
-        private final int operatorId;
-        private final PlanNodeId planNodeId;
-        private final List<Type> sourceTypes;
         private final DataType[] sourceDataTypes;
         private final AggregationNode.Step step;
         private final FunctionType[] aggregatorTypes;
@@ -221,18 +217,6 @@ public class AggregationOmniOperator
         {
             return new AggregationOmniOperatorFactory(operatorId, planNodeId, sourceTypes, aggregatorTypes,
                     aggregationInputChannels, maskChannels, aggregationOutputTypes, step);
-        }
-
-        @Override
-        public boolean isExtensionOperatorFactory()
-        {
-            return true;
-        }
-
-        @Override
-        public List<Type> getSourceTypes()
-        {
-            return sourceTypes;
         }
     }
 }

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/BuildOffHeapOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/BuildOffHeapOmniOperator.java
@@ -117,25 +117,19 @@ public class BuildOffHeapOmniOperator
      * @since 20220110
      */
     public static class BuildOffHeapOmniOperatorFactory
-            implements OperatorFactory
+            extends AbstractOmniOperatorFactory
     {
-        private final int operatorId;
-
-        private final PlanNodeId planNodeId;
-
-        private final List<Type> inputTypes;
-
         /**
          * Instantiates a new buildOffHeapOmniOperator factory.
          *
          * @param operatorId the operator id
          * @param planNodeId the plan node id
          */
-        public BuildOffHeapOmniOperatorFactory(int operatorId, PlanNodeId planNodeId, List<Type> inputTypes)
+        public BuildOffHeapOmniOperatorFactory(int operatorId, PlanNodeId planNodeId, List<Type> sourceTypes)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
-            this.inputTypes = inputTypes;
+            this.sourceTypes = sourceTypes;
         }
 
         @Override
@@ -145,7 +139,7 @@ public class BuildOffHeapOmniOperator
                     VecAllocator.UNLIMIT, VecAllocatorHelper.DEFAULT_RESERVATION, BuildOffHeapOmniOperator.class);
             OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId,
                     BuildOffHeapOmniOperator.class.getSimpleName());
-            return new BuildOffHeapOmniOperator(operatorContext, vecAllocator, inputTypes);
+            return new BuildOffHeapOmniOperator(operatorContext, vecAllocator, sourceTypes);
         }
 
         @Override
@@ -156,13 +150,7 @@ public class BuildOffHeapOmniOperator
         @Override
         public OperatorFactory duplicate()
         {
-            return new BuildOffHeapOmniOperatorFactory(operatorId, planNodeId, inputTypes);
-        }
-
-        @Override
-        public boolean isExtensionOperatorFactory()
-        {
-            return true;
+            return new BuildOffHeapOmniOperatorFactory(operatorId, planNodeId, sourceTypes);
         }
     }
 }

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/BuildOnHeapOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/BuildOnHeapOmniOperator.java
@@ -112,12 +112,8 @@ public class BuildOnHeapOmniOperator
      * @since 20220110
      */
     public static class BuildOnHeapOmniOperatorFactory
-            implements OperatorFactory
+            extends AbstractOmniOperatorFactory
     {
-        private final int operatorId;
-
-        private final PlanNodeId planNodeId;
-
         /**
          * Instantiates a new buildOnHeapOmniOperator factory.
          *
@@ -147,12 +143,6 @@ public class BuildOnHeapOmniOperator
         public OperatorFactory duplicate()
         {
             return new BuildOnHeapOmniOperatorFactory(operatorId, planNodeId);
-        }
-
-        @Override
-        public boolean isExtensionOperatorFactory()
-        {
-            return true;
         }
     }
 }

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/DistinctLimitOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/DistinctLimitOmniOperator.java
@@ -55,14 +55,8 @@ public class DistinctLimitOmniOperator
      * @since 20210630
      */
     public static class DistinctLimitOmniOperatorFactory
-            implements OperatorFactory
+            extends AbstractOmniOperatorFactory
     {
-        private final int operatorId;
-
-        private final PlanNodeId planNodeId;
-
-        private final List<Type> sourceTypes;
-
         private final List<Integer> distinctChannels;
 
         private final Optional<Integer> hashChannel;
@@ -133,18 +127,6 @@ public class DistinctLimitOmniOperator
         {
             return new DistinctLimitOmniOperator.DistinctLimitOmniOperatorFactory(operatorId, planNodeId, sourceTypes,
                     distinctChannels, hashChannel, limit);
-        }
-
-        @Override
-        public boolean isExtensionOperatorFactory()
-        {
-            return true;
-        }
-
-        @Override
-        public List<Type> getSourceTypes()
-        {
-            return sourceTypes;
         }
     }
 

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/DynamicFilterSourceOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/DynamicFilterSourceOmniOperator.java
@@ -64,16 +64,13 @@ public class DynamicFilterSourceOmniOperator
     }
 
     public static class DynamicFilterSourceOmniOperatorFactory
-            implements OperatorFactory
+            extends AbstractOmniOperatorFactory
     {
-        private final int operatorId;
-        private final PlanNodeId planNodeId;
         private final Consumer<Map<Channel, Set>> dynamicPredicateConsumer;
         private final List<Channel> channels;
         private final int maxFilterPositionsCount;
         private final DataSize maxFilterSize;
         private boolean closed;
-        private final List<Type> sourceTypes;
 
         /**
          * Constructor for the Dynamic Filter Source Omni Operator Factory
@@ -119,18 +116,6 @@ public class DynamicFilterSourceOmniOperator
         {
             throw new UnsupportedOperationException(
                     "duplicate() is not supported for DynamicFilterSourceOmniOperatorFactory");
-        }
-
-        @Override
-        public boolean isExtensionOperatorFactory()
-        {
-            return true;
-        }
-
-        @Override
-        public List<Type> getSourceTypes()
-        {
-            return sourceTypes;
         }
     }
 }

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/EnforceSingleRowOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/EnforceSingleRowOmniOperator.java
@@ -67,12 +67,9 @@ public class EnforceSingleRowOmniOperator
      * The enforce single row omni operator factory.
      */
     public static class EnforceSingleRowOmniOperatorFactory
-            implements OperatorFactory
+            extends AbstractOmniOperatorFactory
     {
-        private final int operatorId;
-        private final PlanNodeId planNodeId;
         private boolean closed;
-        private final List<Type> sourceTypes;
 
         /**
          * Instantiates a new Enforce single row omni operator factory.
@@ -108,18 +105,6 @@ public class EnforceSingleRowOmniOperator
         public OperatorFactory duplicate()
         {
             return new EnforceSingleRowOmniOperatorFactory(operatorId, planNodeId, sourceTypes);
-        }
-
-        @Override
-        public boolean isExtensionOperatorFactory()
-        {
-            return true;
-        }
-
-        @Override
-        public List<Type> getSourceTypes()
-        {
-            return sourceTypes;
         }
     }
 }

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/HashAggregationOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/HashAggregationOmniOperator.java
@@ -170,24 +170,12 @@ public class HashAggregationOmniOperator
      * @since 20210630
      */
     public static class HashAggregationOmniOperatorFactory
-            implements OperatorFactory
+            extends AbstractOmniOperatorFactory
     {
         private static final int INVALID_MASK_CHANNEL = -1;
         private final OmniHashAggregationOperatorFactory omniFactory;
 
         private final Step step;
-
-        private List<Type> sourceTypes;
-
-        /**
-         * The Operator id.
-         */
-        int operatorId;
-
-        /**
-         * The Plan node id.
-         */
-        PlanNodeId planNodeId;
 
         private int[] groupByInputChannels;
 
@@ -327,18 +315,6 @@ public class HashAggregationOmniOperator
             return new HashAggregationOmniOperatorFactory(operatorId, planNodeId, sourceTypes, groupByInputChannels,
                     groupByInputTypes, aggregationInputChannels, aggregationInputTypes, aggregatorTypes, maskChannels,
                     aggregationOutputTypes, step);
-        }
-
-        @Override
-        public boolean isExtensionOperatorFactory()
-        {
-            return true;
-        }
-
-        @Override
-        public List<Type> getSourceTypes()
-        {
-            return sourceTypes;
         }
     }
 }

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/HashBuilderOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/HashBuilderOmniOperator.java
@@ -70,12 +70,8 @@ public class HashBuilderOmniOperator
      * @since 20210630
      */
     public static class HashBuilderOmniOperatorFactory
-            implements OperatorFactory
+            extends AbstractOmniOperatorFactory
     {
-        private final int operatorId;
-
-        private final PlanNodeId planNodeId;
-
         private final JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactoryManager;
 
         private final List<Integer> outputChannels;
@@ -85,8 +81,6 @@ public class HashBuilderOmniOperator
         private final Map<Lifespan, Integer> partitionIndexManager = new HashMap<>();
 
         private final OmniHashBuilderOperatorFactory omniHashBuilderOperatorFactory;
-
-        private final List<Type> buildTypes;
 
         private boolean closed;
 
@@ -123,7 +117,7 @@ public class HashBuilderOmniOperator
 
             this.outputChannels = ImmutableList.copyOf(requireNonNull(outputChannels, "outputChannels is null"));
             this.preComputedHashChannel = requireNonNull(preComputedHashChannel, "preComputedHashChannel is null");
-            this.buildTypes = ImmutableList.copyOf(requireNonNull(buildTypes, "sourceTypes is null"));
+            this.sourceTypes = ImmutableList.copyOf(requireNonNull(buildTypes, "buildTypes is null"));
 
             DataType[] omniBuildTypes = OperatorUtils.toDataTypes(buildTypes);
             String[] omniSearchFunctions = searchFunctions.stream().toArray(String[]::new);
@@ -161,12 +155,6 @@ public class HashBuilderOmniOperator
             throw new UnsupportedOperationException("Parallel hash build can not be duplicated");
         }
 
-        @Override
-        public boolean isExtensionOperatorFactory()
-        {
-            return true;
-        }
-
         /**
          * Gets output channels.
          *
@@ -190,12 +178,6 @@ public class HashBuilderOmniOperator
         private int getAndIncrementPartitionIndex(Lifespan lifespan)
         {
             return partitionIndexManager.compute(lifespan, (k, v) -> v == null ? 1 : v + 1) - 1;
-        }
-
-        @Override
-        public List<Type> getSourceTypes()
-        {
-            return buildTypes;
         }
     }
 

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/LimitOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/LimitOmniOperator.java
@@ -150,17 +150,11 @@ public class LimitOmniOperator
      * @since 20210630
      */
     public static class LimitOmniOperatorFactory
-            implements OperatorFactory
+            extends AbstractOmniOperatorFactory
     {
-        private final int operatorId;
-
-        private final PlanNodeId planNodeId;
-
         private final long limit;
 
         private final OmniLimitOperatorFactory omniLimitOperatorFactory;
-
-        private List<Type> sourceTypes;
 
         /**
          * Instantiates a new Top n omni operator factory.
@@ -203,18 +197,6 @@ public class LimitOmniOperator
         public OperatorFactory duplicate()
         {
             return new LimitOmniOperatorFactory(operatorId, planNodeId, limit, sourceTypes);
-        }
-
-        @Override
-        public boolean isExtensionOperatorFactory()
-        {
-            return true;
-        }
-
-        @Override
-        public List<Type> getSourceTypes()
-        {
-            return sourceTypes;
         }
     }
 }

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/LocalMergeSourceOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/LocalMergeSourceOmniOperator.java
@@ -55,15 +55,9 @@ public class LocalMergeSourceOmniOperator
      * @since 20210630
      */
     public static class LocalMergeSourceOmniOperatorFactory
-            implements OperatorFactory
+            extends AbstractOmniOperatorFactory
     {
-        private final int operatorId;
-
-        private final PlanNodeId planNodeId;
-
         private final OmniLocalExchange.LocalExchangeFactory localExchangeFactory;
-
-        private final List<Type> sourceTypes;
 
         private boolean closed;
 
@@ -124,18 +118,6 @@ public class LocalMergeSourceOmniOperator
         public OperatorFactory duplicate()
         {
             throw new UnsupportedOperationException("Source operator factories can not be duplicated");
-        }
-
-        @Override
-        public boolean isExtensionOperatorFactory()
-        {
-            return true;
-        }
-
-        @Override
-        public List<Type> getSourceTypes()
-        {
-            return sourceTypes;
         }
     }
 

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/LookupJoinOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/LookupJoinOmniOperator.java
@@ -289,14 +289,9 @@ public class LookupJoinOmniOperator
      * @since 20210630
      */
     public static class LookupJoinOmniOperatorFactory
+            extends AbstractOmniOperatorFactory
             implements JoinOperatorFactory
     {
-        private final int operatorId;
-
-        private final PlanNodeId planNodeId;
-
-        private final List<Type> probeTypes;
-
         private final JoinType joinType;
 
         private final Optional<OuterOperatorFactoryResult> outerOperatorFactoryResult;
@@ -332,7 +327,7 @@ public class LookupJoinOmniOperator
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
-            this.probeTypes = ImmutableList.copyOf(requireNonNull(probeTypes, "probeTypes is null"));
+            this.sourceTypes = ImmutableList.copyOf(requireNonNull(probeTypes, "probeTypes is null"));
             this.joinType = requireNonNull(joinType, "joinType is null");
 
             this.joinBridgeManager = lookupSourceFactoryManager;
@@ -391,7 +386,7 @@ public class LookupJoinOmniOperator
 
             operatorId = other.operatorId;
             planNodeId = other.planNodeId;
-            probeTypes = other.probeTypes;
+            sourceTypes = other.sourceTypes;
             joinType = other.joinType;
             joinBridgeManager = other.joinBridgeManager;
             outerOperatorFactoryResult = other.outerOperatorFactoryResult;
@@ -418,7 +413,7 @@ public class LookupJoinOmniOperator
 
             joinBridgeManager.probeOperatorCreated(driverContext.getLifespan());
             OmniOperator omniOperator = omniLookupJoinOperatorFactory.createOperator(vecAllocator);
-            return new LookupJoinOmniOperator(operatorContext, probeTypes, joinType, lookupSourceFactory,
+            return new LookupJoinOmniOperator(operatorContext, sourceTypes, joinType, lookupSourceFactory,
                     () -> joinBridgeManager.probeOperatorClosed(driverContext.getLifespan()), omniOperator);
         }
 
@@ -446,18 +441,6 @@ public class LookupJoinOmniOperator
         public Optional<OuterOperatorFactoryResult> createOuterOperatorFactory()
         {
             return outerOperatorFactoryResult;
-        }
-
-        @Override
-        public boolean isExtensionOperatorFactory()
-        {
-            return true;
-        }
-
-        @Override
-        public List<Type> getSourceTypes()
-        {
-            return probeTypes;
         }
     }
 }

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/OrderByOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/OrderByOmniOperator.java
@@ -69,14 +69,8 @@ public class OrderByOmniOperator
      * @since 20210630
      */
     public static class OrderByOmniOperatorFactory
-            implements OperatorFactory
+            extends AbstractOmniOperatorFactory
     {
-        private final int operatorId;
-
-        private final PlanNodeId planNodeId;
-
-        private final List<Type> sourceTypes;
-
         private final int[] outputChannels;
 
         private final int[] sortChannels;
@@ -200,18 +194,6 @@ public class OrderByOmniOperator
         {
             return new OrderByOmniOperatorFactory(operatorId, planNodeId, sourceTypes, outputChannels, sortChannels,
                     sortAscendings, sortNullFirsts, omniSortOperatorFactory);
-        }
-
-        @Override
-        public boolean isExtensionOperatorFactory()
-        {
-            return true;
-        }
-
-        @Override
-        public List<Type> getSourceTypes()
-        {
-            return sourceTypes;
         }
     }
 

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/PartitionedOutputOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/PartitionedOutputOmniOperator.java
@@ -211,11 +211,8 @@ public class PartitionedOutputOmniOperator
     }
 
     private static class PartitionedOutputOmniOperatorFactory
-            implements OperatorFactory
+            extends AbstractOmniOperatorFactory
     {
-        private final int operatorId;
-        private final PlanNodeId planNodeId;
-        private final List<Type> sourceTypes;
         private final Function<Page, Page> pagePreprocessor;
         private final PartitionFunction partitionFunction;
         private final List<Integer> partitionChannels;
@@ -267,23 +264,11 @@ public class PartitionedOutputOmniOperator
         }
 
         @Override
-        public boolean isExtensionOperatorFactory()
-        {
-            return true;
-        }
-
-        @Override
         public OperatorFactory duplicate()
         {
             return new PartitionedOutputOmniOperatorFactory(operatorId, planNodeId, sourceTypes, pagePreprocessor,
                     partitionFunction, partitionChannels, partitionConstants, replicatesAnyRow, nullChannel,
                     outputBuffer, maxMemory, omniPartitionedOutPutOperatorFactory);
-        }
-
-        @Override
-        public List<Type> getSourceTypes()
-        {
-            return sourceTypes;
         }
     }
 

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/TopNOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/TopNOmniOperator.java
@@ -151,14 +151,8 @@ public class TopNOmniOperator
      * @since 20210630
      */
     public static class TopNOmniOperatorFactory
-            implements OperatorFactory
+            extends AbstractOmniOperatorFactory
     {
-        private final int operatorId;
-
-        private final PlanNodeId planNodeId;
-
-        private final List<Type> sourceTypes;
-
         private final int topN;
 
         private final ImmutableList<Integer> sortChannels;
@@ -236,18 +230,6 @@ public class TopNOmniOperator
         public OperatorFactory duplicate()
         {
             return new TopNOmniOperatorFactory(operatorId, planNodeId, sourceTypes, topN, sortChannels, sortOrders);
-        }
-
-        @Override
-        public boolean isExtensionOperatorFactory()
-        {
-            return true;
-        }
-
-        @Override
-        public List<Type> getSourceTypes()
-        {
-            return sourceTypes;
         }
     }
 }

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/WindowOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/WindowOmniOperator.java
@@ -164,14 +164,8 @@ public class WindowOmniOperator
      * @since 20210630
      */
     public static class WindowOmniOperatorFactory
-            implements OperatorFactory
+            extends AbstractOmniOperatorFactory
     {
-        private final int operatorId;
-
-        private final PlanNodeId planNodeId;
-
-        private final List<Type> sourceTypes;
-
         private final ImmutableList<Integer> outputChannels;
 
         private final ImmutableList<WindowFunctionDefinition> windowFunctionDefinitions;
@@ -426,18 +420,6 @@ public class WindowOmniOperator
             return new WindowOmniOperatorFactory(operatorId, planNodeId, sourceTypes, outputChannels,
                     windowFunctionDefinitions, partitionChannels, preGroupedChannels, sortChannels, sortOrder,
                     preSortedChannelPrefix, expectedPositions);
-        }
-
-        @Override
-        public boolean isExtensionOperatorFactory()
-        {
-            return true;
-        }
-
-        @Override
-        public List<Type> getSourceTypes()
-        {
-            return sourceTypes;
         }
     }
 }

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/filterandproject/FilterAndProjectOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/filterandproject/FilterAndProjectOmniOperator.java
@@ -26,6 +26,7 @@ import io.prestosql.operator.project.PageProcessor;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.plan.PlanNodeId;
 import io.prestosql.spi.type.Type;
+import nova.hetu.olk.operator.AbstractOmniOperatorFactory;
 
 import java.util.List;
 import java.util.function.Supplier;
@@ -109,12 +110,8 @@ public class FilterAndProjectOmniOperator
     }
 
     public static class FilterAndProjectOmniOperatorFactory
-            implements OperatorFactory
+            extends AbstractOmniOperatorFactory
     {
-        private final int operatorId;
-
-        private final PlanNodeId planNodeId;
-
         private final Supplier<PageProcessor> processor;
 
         private final List<Type> types;
@@ -124,6 +121,14 @@ public class FilterAndProjectOmniOperator
         private final int minOutputPageRowCount;
 
         private boolean closed;
+
+        public FilterAndProjectOmniOperatorFactory(int operatorId, PlanNodeId planNodeId,
+                                                   Supplier<PageProcessor> processor, List<Type> types, DataSize minOutputPageSize,
+                                                   int minOutputPageRowCount, List<Type> sourceTypes)
+        {
+            this(operatorId, planNodeId, processor, types, minOutputPageSize, minOutputPageRowCount);
+            this.sourceTypes = sourceTypes;
+        }
 
         public FilterAndProjectOmniOperatorFactory(int operatorId, PlanNodeId planNodeId,
                                                    Supplier<PageProcessor> processor, List<Type> types, DataSize minOutputPageSize,
@@ -157,13 +162,7 @@ public class FilterAndProjectOmniOperator
         public OperatorFactory duplicate()
         {
             return new FilterAndProjectOmniOperatorFactory(operatorId, planNodeId, processor, types, minOutputPageSize,
-                    minOutputPageRowCount);
-        }
-
-        @Override
-        public boolean isExtensionOperatorFactory()
-        {
-            return true;
+                    minOutputPageRowCount, sourceTypes);
         }
     }
 }

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/localexchange/LocalExchangeSinkOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/localexchange/LocalExchangeSinkOmniOperator.java
@@ -28,6 +28,7 @@ import io.prestosql.operator.exchange.LocalExchangeSinkOperator;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.plan.PlanNodeId;
 import io.prestosql.spi.type.Type;
+import nova.hetu.olk.operator.AbstractOmniOperatorFactory;
 
 import java.util.List;
 import java.util.function.Function;
@@ -51,20 +52,17 @@ public class LocalExchangeSinkOmniOperator
      * The Local exchange sink omni operator factory.
      */
     public static class LocalExchangeSinkOmniOperatorFactory
-            implements OperatorFactory, LocalPlannerAware
+            extends AbstractOmniOperatorFactory implements LocalPlannerAware
     {
         private final LocalExchange.LocalExchangeFactory localExchangeFactory;
 
-        private final int operatorId;
         // There will be a LocalExchangeSinkFactory per LocalExchangeSinkOperatorFactory
         // per Driver Group.
         // A LocalExchangeSinkOperatorFactory needs to have access to
         // LocalExchangeSinkFactories for each Driver Group.
         private final LocalExchange.LocalExchangeSinkFactoryId sinkFactoryId;
-        private final PlanNodeId planNodeId;
         private final Function<Page, Page> pagePreprocessor;
         private boolean closed;
-        private final List<Type> sourceTypes;
 
         public LocalExchangeSinkOmniOperatorFactory(LocalExchange.LocalExchangeFactory localExchangeFactory,
                                                     int operatorId, PlanNodeId planNodeId, LocalExchange.LocalExchangeSinkFactoryId sinkFactoryId,
@@ -122,18 +120,6 @@ public class LocalExchangeSinkOmniOperator
         public void localPlannerComplete()
         {
             localExchangeFactory.noMoreSinkFactories();
-        }
-
-        @Override
-        public boolean isExtensionOperatorFactory()
-        {
-            return true;
-        }
-
-        @Override
-        public List<Type> getSourceTypes()
-        {
-            return sourceTypes;
         }
     }
 }

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/localexchange/LocalExchangeSourceOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/localexchange/LocalExchangeSourceOmniOperator.java
@@ -25,6 +25,7 @@ import io.prestosql.operator.exchange.LocalExchangeSource;
 import io.prestosql.operator.exchange.LocalExchangeSourceOperator;
 import io.prestosql.spi.plan.PlanNodeId;
 import io.prestosql.spi.type.Type;
+import nova.hetu.olk.operator.AbstractOmniOperatorFactory;
 
 import java.util.List;
 
@@ -47,14 +48,11 @@ public class LocalExchangeSourceOmniOperator
      * The Local exchange source omni operator factory.
      */
     public static class LocalExchangeSourceOmniOperatorFactory
-            implements OperatorFactory
+            extends AbstractOmniOperatorFactory
     {
-        private final int operatorId;
-        private final PlanNodeId planNodeId;
         private final LocalExchange.LocalExchangeFactory localExchangeFactory;
         private final int totalInputChannels;
         private boolean closed;
-        private final List<Type> sourceTypes;
 
         public LocalExchangeSourceOmniOperatorFactory(int operatorId, PlanNodeId planNodeId,
                                                       LocalExchange.LocalExchangeFactory localExchangeFactory, int totalInputChannels, List<Type> types)
@@ -96,18 +94,6 @@ public class LocalExchangeSourceOmniOperator
         public LocalExchange.LocalExchangeFactory getLocalExchangeFactory()
         {
             return localExchangeFactory;
-        }
-
-        @Override
-        public boolean isExtensionOperatorFactory()
-        {
-            return true;
-        }
-
-        @Override
-        public List<Type> getSourceTypes()
-        {
-            return sourceTypes;
         }
     }
 }


### PR DESCRIPTION
Use AbstractOmniOperatorFactory implement from interface OperatorFactory, where we can extract some general fields and methods from all OmniOperatorFactories, and transformer Operators can be shown in web ui easily by planNode id and incremental operator id.