### PR TITLE
fix memory leak if cancel query

### DIFF
--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/OmniLocalExecutionPlanner.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/OmniLocalExecutionPlanner.java
@@ -815,7 +815,7 @@ public class OmniLocalExecutionPlanner
                             getFilterAndProjectMinOutputPageSize(session),
                             getFilterAndProjectMinOutputPageRowCount(session), strategy, reuseTableScanMappingId,
                             spillEnabled, Optional.of(spillerFactory), spillerThreshold, consumerTableScanNodeCount,
-                            inputTypes);
+                            inputTypes, (OmniLocalExecutionPlanContext) context);
                 }
                 else {
                     operatorFactory = new ScanFilterAndProjectOperator.ScanFilterAndProjectOperatorFactory(

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/BuildOnHeapOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/BuildOnHeapOmniOperator.java
@@ -106,6 +106,14 @@ public class BuildOnHeapOmniOperator
         return transferToOnHeapPage(inputPage);
     }
 
+    @Override
+    public void close() throws Exception
+    {
+        if (inputPage != null) {
+            BlockUtils.freePage(inputPage);
+        }
+    }
+
     /**
      * The type buildOnHeapOmniOperator factory.
      *

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/DistinctLimitOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/DistinctLimitOmniOperator.java
@@ -23,6 +23,7 @@ import io.prestosql.operator.OperatorFactory;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.plan.PlanNodeId;
 import io.prestosql.spi.type.Type;
+import nova.hetu.olk.tool.BlockUtils;
 import nova.hetu.olk.tool.OperatorUtils;
 import nova.hetu.olk.tool.VecAllocatorHelper;
 import nova.hetu.olk.tool.VecBatchToPageIterator;
@@ -188,6 +189,13 @@ public class DistinctLimitOmniOperator
     @Override
     public void close() throws Exception
     {
+        // free page if it has next
+        if (pages != null) {
+            while (pages.hasNext()) {
+                Page next = pages.next();
+                BlockUtils.freePage(next);
+            }
+        }
         omniOperator.close();
     }
 

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/DynamicFilterSourceOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/DynamicFilterSourceOmniOperator.java
@@ -23,6 +23,7 @@ import io.prestosql.operator.OperatorFactory;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.plan.PlanNodeId;
 import io.prestosql.spi.type.Type;
+import nova.hetu.olk.tool.BlockUtils;
 import nova.hetu.olk.tool.VecAllocatorHelper;
 import nova.hetu.omniruntime.vector.VecAllocator;
 
@@ -44,6 +45,7 @@ public class DynamicFilterSourceOmniOperator
         extends DynamicFilterSourceOperator
 {
     private VecAllocator vecAllocator;
+    private Page page;
 
     /**
      * Constructor for the Dynamic Filter Source Operator TODO: no need to collect
@@ -60,7 +62,24 @@ public class DynamicFilterSourceOmniOperator
     @Override
     public void addInput(Page page)
     {
+        this.page = page;
         super.addInput(page);
+    }
+
+    @Override
+    public Page getOutput()
+    {
+        Page output = super.getOutput();
+        page = null;
+        return output;
+    }
+
+    @Override
+    public void close()
+    {
+        if (page != null) {
+            BlockUtils.freePage(page);
+        }
     }
 
     public static class DynamicFilterSourceOmniOperatorFactory

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/HashAggregationOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/HashAggregationOmniOperator.java
@@ -29,6 +29,7 @@ import io.prestosql.spi.plan.AggregationNode;
 import io.prestosql.spi.plan.AggregationNode.Step;
 import io.prestosql.spi.plan.PlanNodeId;
 import io.prestosql.spi.type.Type;
+import nova.hetu.olk.tool.BlockUtils;
 import nova.hetu.olk.tool.VecAllocatorHelper;
 import nova.hetu.olk.tool.VecBatchToPageIterator;
 import nova.hetu.omniruntime.constants.FunctionType;
@@ -107,6 +108,13 @@ public class HashAggregationOmniOperator
     @Override
     public void close()
     {
+        // free pages if it has next
+        if (pages != null) {
+            while (pages.hasNext()) {
+                Page next = pages.next();
+                BlockUtils.freePage(next);
+            }
+        }
         omniOperator.close();
     }
 

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/LimitOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/LimitOmniOperator.java
@@ -22,6 +22,7 @@ import io.prestosql.operator.OperatorFactory;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.plan.PlanNodeId;
 import io.prestosql.spi.type.Type;
+import nova.hetu.olk.tool.BlockUtils;
 import nova.hetu.olk.tool.VecAllocatorHelper;
 import nova.hetu.olk.tool.VecBatchToPageIterator;
 import nova.hetu.omniruntime.operator.OmniOperator;
@@ -88,6 +89,13 @@ public class LimitOmniOperator
     @Override
     public void close() throws Exception
     {
+        // free page if it has next
+        if (pages != null) {
+            while (pages.hasNext()) {
+                Page next = pages.next();
+                BlockUtils.freePage(next);
+            }
+        }
         omniOperator.close();
     }
 

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/LookupJoinOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/LookupJoinOmniOperator.java
@@ -36,6 +36,7 @@ import io.prestosql.operator.StaticLookupSourceProvider;
 import io.prestosql.spi.Page;
 import io.prestosql.spi.plan.PlanNodeId;
 import io.prestosql.spi.type.Type;
+import nova.hetu.olk.tool.BlockUtils;
 import nova.hetu.olk.tool.OperatorUtils;
 import nova.hetu.olk.tool.VecAllocatorHelper;
 import nova.hetu.olk.tool.VecBatchToPageIterator;
@@ -269,6 +270,14 @@ public class LookupJoinOmniOperator
         }
         closed = true;
         omniOperator.close();
+
+        // free result if it has next
+        if (result != null) {
+            while (result.hasNext()) {
+                Page next = result.next();
+                BlockUtils.freePage(next);
+            }
+        }
 
         try (Closer closer = Closer.create()) {
             // `afterClose` must be run last.

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/OrderByOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/OrderByOmniOperator.java
@@ -32,6 +32,7 @@ import io.prestosql.spi.plan.PlanNodeId;
 import io.prestosql.spi.type.Type;
 import io.prestosql.testing.TestingSession;
 import io.prestosql.testing.TestingTaskContext;
+import nova.hetu.olk.tool.BlockUtils;
 import nova.hetu.olk.tool.OperatorUtils;
 import nova.hetu.olk.tool.VecAllocatorHelper;
 import nova.hetu.olk.tool.VecBatchToPageIterator;
@@ -299,6 +300,15 @@ public class OrderByOmniOperator
     @Override
     public void close()
     {
+        // free sortedPages if it has next
+        if (sortedPages != null) {
+            while (sortedPages.hasNext()) {
+                Optional<Page> next = sortedPages.next();
+                if (next.isPresent()) {
+                    BlockUtils.freePage(next.get());
+                }
+            }
+        }
         omniOperator.close();
     }
 }

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/TopNOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/TopNOmniOperator.java
@@ -24,6 +24,7 @@ import io.prestosql.spi.Page;
 import io.prestosql.spi.block.SortOrder;
 import io.prestosql.spi.plan.PlanNodeId;
 import io.prestosql.spi.type.Type;
+import nova.hetu.olk.tool.BlockUtils;
 import nova.hetu.olk.tool.OperatorUtils;
 import nova.hetu.olk.tool.VecAllocatorHelper;
 import nova.hetu.olk.tool.VecBatchToPageIterator;
@@ -93,6 +94,13 @@ public class TopNOmniOperator
     @Override
     public void close() throws Exception
     {
+        // free pages if it has next
+        if (pages != null) {
+            while (pages.hasNext()) {
+                Page next = pages.next();
+                BlockUtils.freePage(next);
+            }
+        }
         omniOperator.close();
     }
 

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/WindowOmniOperator.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/WindowOmniOperator.java
@@ -29,6 +29,7 @@ import io.prestosql.spi.block.SortOrder;
 import io.prestosql.spi.plan.PlanNodeId;
 import io.prestosql.spi.sql.expression.Types;
 import io.prestosql.spi.type.Type;
+import nova.hetu.olk.tool.BlockUtils;
 import nova.hetu.olk.tool.OperatorUtils;
 import nova.hetu.olk.tool.VecAllocatorHelper;
 import nova.hetu.olk.tool.VecBatchToPageIterator;
@@ -97,6 +98,13 @@ public class WindowOmniOperator
     @Override
     public void close() throws Exception
     {
+        // free pages if it has next
+        if (pages != null) {
+            while (pages.hasNext()) {
+                Page next = pages.next();
+                BlockUtils.freePage(next);
+            }
+        }
         omniOperator.close();
     }
 


### PR DESCRIPTION
Close some off-heap pages remained in operators when query was cancelled. The method close() will be invoked, thus we release them here.