### PR TITLE
fix some bugs

### DIFF
--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/block/LazyOmniBlock.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/block/LazyOmniBlock.java
@@ -154,4 +154,10 @@ public class LazyOmniBlock<T>
     {
         return lazyBlock;
     }
+
+    @Override
+    public void close()
+    {
+        nativeLazyVec.close();
+    }
 }

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/block/RowOmniBlock.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/block/RowOmniBlock.java
@@ -67,6 +67,8 @@ public class RowOmniBlock<T>
 
     private final DataType dataType;
 
+    private boolean[] isNull;
+
     /**
      * Create a row block directly from columnar nulls and field blocks.
      *
@@ -238,7 +240,10 @@ public class RowOmniBlock<T>
     @Nullable
     public boolean[] getRowIsNull()
     {
-        boolean[] isNull = new boolean[rowIsNull.length];
+        if (isNull != null) {
+            return isNull;
+        }
+        isNull = new boolean[rowIsNull.length];
         for (int i = 0; i < rowIsNull.length; i++) {
             isNull[i] = rowIsNull[i] == Vec.NULL;
         }

--- a/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/filterandproject/JsonifyVisitor.java
+++ b/omnioperator/omniop-openlookeng-extension/src/main/java/nova/hetu/olk/operator/filterandproject/JsonifyVisitor.java
@@ -230,7 +230,7 @@ class JsonifyVisitor
             case OMNI_VARCHAR:
                 String varcharValue;
                 if (literal.getValue() instanceof Slice) {
-                    varcharValue = ((Slice) literal.getValue()).toStringAscii();
+                    varcharValue = ((Slice) literal.getValue()).toStringUtf8();
                 }
                 else {
                     varcharValue = String.valueOf(literal.getValue());


### PR DESCRIPTION
In TPCDS Q32, the RowOmniBlock.getRowIsNull() has high proportion in cpu flame graph, thus we can reduce repeated generation of isNull array to improve performance.